### PR TITLE
session6 -UIViewControllerのライフサイクル

### DIFF
--- a/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
+++ b/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		CD1C7025266616F800BBF45F /* YumemiWeather in Frameworks */ = {isa = PBXBuildFile; productRef = CD1C7024266616F800BBF45F /* YumemiWeather */; };
 		CD228F75266DF69F00DFA375 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD228F74266DF69F00DFA375 /* Response.swift */; };
 		CD228F77266E048800DFA375 /* JsonError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD228F76266E048800DFA375 /* JsonError.swift */; };
+		CD6CCC88267C6A190026F85F /* NewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CCC87267C6A190026F85F /* NewViewController.swift */; };
 		CDA7E7A826789E19000E932C /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7E7A726789E19000E932C /* Request.swift */; };
 		CDF185962665E9720075F1C1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF185952665E9720075F1C1 /* AppDelegate.swift */; };
 		CDF1859D2665E9720075F1C1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDF1859B2665E9720075F1C1 /* Main.storyboard */; };
@@ -55,6 +56,7 @@
 		CD010BA926677D4F00821658 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		CD228F74266DF69F00DFA375 /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		CD228F76266E048800DFA375 /* JsonError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonError.swift; sourceTree = "<group>"; };
+		CD6CCC87267C6A190026F85F /* NewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewController.swift; sourceTree = "<group>"; };
 		CDA7E7A726789E19000E932C /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		CDF185922665E9720075F1C1 /* Yumemi-Weather.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Yumemi-Weather.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF185952665E9720075F1C1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				CDF998F0266780B5009A1B63 /* ViewController.swift */,
+				CD6CCC87267C6A190026F85F /* NewViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -491,6 +494,7 @@
 				CDF998FA266783EA009A1B63 /* WeatherModel.swift in Sources */,
 				CDF998F726678333009A1B63 /* R.generated.swift in Sources */,
 				CDF998FD26678414009A1B63 /* WeatherView.swift in Sources */,
+				CD6CCC88267C6A190026F85F /* NewViewController.swift in Sources */,
 				CDA7E7A826789E19000E932C /* Request.swift in Sources */,
 				CD228F75266DF69F00DFA375 /* Response.swift in Sources */,
 			);

--- a/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
+++ b/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		CDF185A22665E9730075F1C1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDF185A02665E9730075F1C1 /* LaunchScreen.storyboard */; };
 		CDF185AD2665E9730075F1C1 /* Yumemi_WeatherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF185AC2665E9730075F1C1 /* Yumemi_WeatherTests.swift */; };
 		CDF185B82665E9740075F1C1 /* Yumemi_WeatherUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF185B72665E9740075F1C1 /* Yumemi_WeatherUITests.swift */; };
-		CDF998F1266780B5009A1B63 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF998F0266780B5009A1B63 /* ViewController.swift */; };
+		CDF998F1266780B5009A1B63 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF998F0266780B5009A1B63 /* MainViewController.swift */; };
 		CDF998F726678333009A1B63 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF998F626678333009A1B63 /* R.generated.swift */; };
 		CDF998FA266783EA009A1B63 /* WeatherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF998F9266783EA009A1B63 /* WeatherModel.swift */; };
 		CDF998FD26678414009A1B63 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF998FC26678414009A1B63 /* WeatherView.swift */; };
@@ -70,7 +70,7 @@
 		CDF185B32665E9740075F1C1 /* Yumemi-WeatherUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Yumemi-WeatherUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF185B72665E9740075F1C1 /* Yumemi_WeatherUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Yumemi_WeatherUITests.swift; sourceTree = "<group>"; };
 		CDF185B92665E9740075F1C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		CDF998F0266780B5009A1B63 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		CDF998F0266780B5009A1B63 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		CDF998F626678333009A1B63 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = "<group>"; };
 		CDF998F9266783EA009A1B63 /* WeatherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherModel.swift; sourceTree = "<group>"; };
 		CDF998FC26678414009A1B63 /* WeatherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherView.swift; sourceTree = "<group>"; };
@@ -217,7 +217,7 @@
 		CDF998FE2667842D009A1B63 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				CDF998F0266780B5009A1B63 /* ViewController.swift */,
+				CDF998F0266780B5009A1B63 /* MainViewController.swift */,
 				CD6CCC87267C6A190026F85F /* NewViewController.swift */,
 			);
 			path = Controller;
@@ -490,7 +490,7 @@
 				CD228F77266E048800DFA375 /* JsonError.swift in Sources */,
 				CDF185962665E9720075F1C1 /* AppDelegate.swift in Sources */,
 				CD010BAA26677D4F00821658 /* SceneDelegate.swift in Sources */,
-				CDF998F1266780B5009A1B63 /* ViewController.swift in Sources */,
+				CDF998F1266780B5009A1B63 /* MainViewController.swift in Sources */,
 				CDF998FA266783EA009A1B63 /* WeatherModel.swift in Sources */,
 				CDF998F726678333009A1B63 /* R.generated.swift in Sources */,
 				CDF998FD26678414009A1B63 /* WeatherView.swift in Sources */,

--- a/Yumemi-Weather/Yumemi-Weather/Base.lproj/Main.storyboard
+++ b/Yumemi-Weather/Yumemi-Weather/Base.lproj/Main.storyboard
@@ -13,10 +13,10 @@
         </array>
     </customFonts>
     <scenes>
-        <!--View Controller-->
+        <!--Main View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="MainViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="ViewController" customModule="Yumemi_Weather" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="MainViewController" customModule="Yumemi_Weather" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="WeatherView" customModule="Yumemi_Weather" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Yumemi-Weather/Yumemi-Weather/Base.lproj/Main.storyboard
+++ b/Yumemi-Weather/Yumemi-Weather/Base.lproj/Main.storyboard
@@ -16,7 +16,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Yumemi_Weather" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="ViewController" customModule="Yumemi_Weather" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="WeatherView" customModule="Yumemi_Weather" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -95,6 +95,24 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="34.782608695652179" y="93.75"/>
+        </scene>
+        <!--New View Controller-->
+        <scene sceneID="FlP-Nd-ywL">
+            <objects>
+                <viewController storyboardIdentifier="NewViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="hgL-Jm-GlW" customClass="NewViewController" customModule="Yumemi_Weather" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ruw-Bp-QM4">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="FTs-gn-tyD"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="presentation" identifier="toMainViewController" modalPresentationStyle="fullScreen" id="YA9-sU-dak"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="aHO-70-vC5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="864" y="94"/>
         </scene>
     </scenes>
     <resources>

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+final class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
     private var weatherModel = WeatherModel()
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)
     }
+    
     @IBAction func reloadButton(_ sender: Any) {
         weatherModel.fetchWeather()
     }

--- a/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
@@ -1,0 +1,22 @@
+//
+//  NewViewController.swift
+//  Yumemi-Weather
+//
+//  Created by 清浦 駿 on 2021/06/18.
+//
+
+import UIKit
+
+class NewViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        performSegue(withIdentifier: R.segue.newViewController.toMainViewController.identifier, sender: nil)
+    }
+}

--- a/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
@@ -7,14 +7,8 @@
 
 import UIKit
 
-class NewViewController: UIViewController {
+final class NewViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         performSegue(withIdentifier: R.segue.newViewController.toMainViewController.identifier, sender: nil)

--- a/Yumemi-Weather/Yumemi-Weather/Controller/ViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/ViewController.swift
@@ -13,6 +13,7 @@ class ViewController: UIViewController {
     private var weatherModel = WeatherModel()
     
     @IBAction func closeButton(_ sender: Any) {
+        dismiss(animated: true)
     }
     @IBAction func reloadButton(_ sender: Any) {
         weatherModel.fetchWeather()

--- a/Yumemi-Weather/Yumemi-Weather/SceneDelegate.swift
+++ b/Yumemi-Weather/Yumemi-Weather/SceneDelegate.swift
@@ -17,6 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
+        
+        let newViewController = R.storyboard.main.newViewController()
+        window?.rootViewController = newViewController
+        
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
# 変更理由
- UIViewControllerのライフサイクルを理解し、適切なサイクルで処理をおこなえるようにする

# どう変更したのか
- 天気を表示するviewControllerのidentifyをMainViewControllerに
- NewViewControllerを作成
- MainViewControllerのcloseボタンを押すと画面がdismissするように
- アプリが起動した際にNewViewControllerに遷移
- NewViewControllerが表示されたらMainViewControllerに遷移

# 参考資料
- [iOS13のSceneDelegate周りのアプリの起動シーケンス (Qiita)](https://qiita.com/omochimetaru/items/31df103ef98a9d84ae6b#sceneの再利用)
- [iOSアプリのライフサイクル (Qiita)](https://qiita.com/KenNagami/items/766d5f95940c76a8c3cd)