### PR TITLE
session7 -Notification Center

### DIFF
--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -23,6 +23,12 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.viewWillEnterForeground(_:)),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
         weatherModel.notificationCenter.addObserver(
             self,
             selector: #selector(self.handleWeatherChange(_:)),
@@ -35,6 +41,10 @@ final class MainViewController: UIViewController {
             name: .errorOccurred,
             object: nil
         )
+    }
+    
+    @objc func viewWillEnterForeground(_ notification: Notification) {
+        weatherModel.fetchWeather()
     }
     
     @objc func handleWeatherChange(_ notification: Notification) {


### PR DESCRIPTION
# 変更理由
- Notification Centerを利用してobserveパターンを実現するため

# 変更点
- UIApplication.willEnterForegroundNotification をObserveしてviewがフォアグラウンドになったことを検知
- viewWillEnterForeground(_ notification: Notification)にフォアグラウンドになった時の処理を記述

# 参考資料
[【Swift】iOSアプリがフォアグラウンドになった時に、更新処理をさせてみたい！ (Qiita)](https://qiita.com/mushroominger/items/b03860d8a0a746dcd164)
