### PR TITLE
session8 -テストの実装

### DIFF
--- a/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
+++ b/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		CD228F77266E048800DFA375 /* JsonError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD228F76266E048800DFA375 /* JsonError.swift */; };
 		CD6CCC88267C6A190026F85F /* NewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CCC87267C6A190026F85F /* NewViewController.swift */; };
 		CDA7E7A826789E19000E932C /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7E7A726789E19000E932C /* Request.swift */; };
+		CDC76942268C072F005D7414 /* JsonParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC76941268C072F005D7414 /* JsonParseTests.swift */; };
 		CDF185962665E9720075F1C1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF185952665E9720075F1C1 /* AppDelegate.swift */; };
 		CDF1859D2665E9720075F1C1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDF1859B2665E9720075F1C1 /* Main.storyboard */; };
 		CDF1859F2665E9730075F1C1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CDF1859E2665E9730075F1C1 /* Assets.xcassets */; };
@@ -58,6 +59,7 @@
 		CD228F76266E048800DFA375 /* JsonError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonError.swift; sourceTree = "<group>"; };
 		CD6CCC87267C6A190026F85F /* NewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewController.swift; sourceTree = "<group>"; };
 		CDA7E7A726789E19000E932C /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		CDC76941268C072F005D7414 /* JsonParseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonParseTests.swift; sourceTree = "<group>"; };
 		CDF185922665E9720075F1C1 /* Yumemi-Weather.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Yumemi-Weather.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF185952665E9720075F1C1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CDF1859C2665E9720075F1C1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 			children = (
 				CDF185AC2665E9730075F1C1 /* Yumemi_WeatherTests.swift */,
 				CDF185AE2665E9730075F1C1 /* Info.plist */,
+				CDC76941268C072F005D7414 /* JsonParseTests.swift */,
 			);
 			path = "Yumemi-WeatherTests";
 			sourceTree = "<group>";
@@ -505,6 +508,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDF185AD2665E9730075F1C1 /* Yumemi_WeatherTests.swift in Sources */,
+				CDC76942268C072F005D7414 /* JsonParseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
+++ b/Yumemi-Weather/Yumemi-Weather.xcodeproj/project.pbxproj
@@ -15,7 +15,8 @@
 		CD228F77266E048800DFA375 /* JsonError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD228F76266E048800DFA375 /* JsonError.swift */; };
 		CD6CCC88267C6A190026F85F /* NewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CCC87267C6A190026F85F /* NewViewController.swift */; };
 		CDA7E7A826789E19000E932C /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7E7A726789E19000E932C /* Request.swift */; };
-		CDC76942268C072F005D7414 /* JsonParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC76941268C072F005D7414 /* JsonParseTests.swift */; };
+		CDC76942268C072F005D7414 /* JsonParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC76941268C072F005D7414 /* JsonParserTests.swift */; };
+		CDC76944268D96E4005D7414 /* JsonParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC76943268D96E4005D7414 /* JsonParser.swift */; };
 		CDF185962665E9720075F1C1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF185952665E9720075F1C1 /* AppDelegate.swift */; };
 		CDF1859D2665E9720075F1C1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CDF1859B2665E9720075F1C1 /* Main.storyboard */; };
 		CDF1859F2665E9730075F1C1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CDF1859E2665E9730075F1C1 /* Assets.xcassets */; };
@@ -59,7 +60,8 @@
 		CD228F76266E048800DFA375 /* JsonError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonError.swift; sourceTree = "<group>"; };
 		CD6CCC87267C6A190026F85F /* NewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewViewController.swift; sourceTree = "<group>"; };
 		CDA7E7A726789E19000E932C /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		CDC76941268C072F005D7414 /* JsonParseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonParseTests.swift; sourceTree = "<group>"; };
+		CDC76941268C072F005D7414 /* JsonParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonParserTests.swift; sourceTree = "<group>"; };
+		CDC76943268D96E4005D7414 /* JsonParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonParser.swift; sourceTree = "<group>"; };
 		CDF185922665E9720075F1C1 /* Yumemi-Weather.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Yumemi-Weather.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF185952665E9720075F1C1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CDF1859C2665E9720075F1C1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				CDF1859E2665E9730075F1C1 /* Assets.xcassets */,
 				CDF185A02665E9730075F1C1 /* LaunchScreen.storyboard */,
 				CDF185A32665E9730075F1C1 /* Info.plist */,
+				CDC76943268D96E4005D7414 /* JsonParser.swift */,
 			);
 			path = "Yumemi-Weather";
 			sourceTree = "<group>";
@@ -187,7 +190,7 @@
 			children = (
 				CDF185AC2665E9730075F1C1 /* Yumemi_WeatherTests.swift */,
 				CDF185AE2665E9730075F1C1 /* Info.plist */,
-				CDC76941268C072F005D7414 /* JsonParseTests.swift */,
+				CDC76941268C072F005D7414 /* JsonParserTests.swift */,
 			);
 			path = "Yumemi-WeatherTests";
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 				CDF998FD26678414009A1B63 /* WeatherView.swift in Sources */,
 				CD6CCC88267C6A190026F85F /* NewViewController.swift in Sources */,
 				CDA7E7A826789E19000E932C /* Request.swift in Sources */,
+				CDC76944268D96E4005D7414 /* JsonParser.swift in Sources */,
 				CD228F75266DF69F00DFA375 /* Response.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -508,7 +512,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDF185AD2665E9730075F1C1 /* Yumemi_WeatherTests.swift in Sources */,
-				CDC76942268C072F005D7414 /* JsonParseTests.swift in Sources */,
+				CDC76942268C072F005D7414 /* JsonParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Yumemi-Weather/Yumemi-Weather.xcodeproj/xcshareddata/xcschemes/Yumemi-Weather.xcscheme
+++ b/Yumemi-Weather/Yumemi-Weather.xcodeproj/xcshareddata/xcschemes/Yumemi-Weather.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDF185912665E9720075F1C1"
+               BuildableName = "Yumemi-Weather.app"
+               BlueprintName = "Yumemi-Weather"
+               ReferencedContainer = "container:Yumemi-Weather.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDF185A72665E9730075F1C1"
+               BuildableName = "Yumemi-WeatherTests.xctest"
+               BlueprintName = "Yumemi-WeatherTests"
+               ReferencedContainer = "container:Yumemi-Weather.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "Yumemi_WeatherTests/testExampleb()">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CDF185B22665E9740075F1C1"
+               BuildableName = "Yumemi-WeatherUITests.xctest"
+               BlueprintName = "Yumemi-WeatherUITests"
+               ReferencedContainer = "container:Yumemi-Weather.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDF185912665E9720075F1C1"
+            BuildableName = "Yumemi-Weather.app"
+            BlueprintName = "Yumemi-Weather"
+            ReferencedContainer = "container:Yumemi-Weather.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CDF185912665E9720075F1C1"
+            BuildableName = "Yumemi-Weather.app"
+            BlueprintName = "Yumemi-Weather"
+            ReferencedContainer = "container:Yumemi-Weather.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -9,9 +9,7 @@ import UIKit
 import YumemiWeather
 
 protocol  WeatherModel {
-    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void)
-    func request<T: Encodable>(from value: T) throws -> String
-    func decode<T: Decodable>(from value: String) throws -> T
+    func fetchWeather(completion: (Result<Response, Error>) -> Void)
 }
 
 final class MainViewController: UIViewController {
@@ -59,7 +57,7 @@ final class MainViewController: UIViewController {
         var message: String
         
         switch error {
-        case let error as YumemiWeatherError:
+        case let error as WeatherError:
             switch error {
             case .invalidParameterError:
                 message = "Yumemi Weather Error\n'Invalid Parameter'"

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -7,10 +7,6 @@
 
 import UIKit
 
-protocol  WeatherModel {
-    func fetchWeather(completion: (Result<Response, Error>) -> Void)
-}
-
 final class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
@@ -20,10 +16,10 @@ final class MainViewController: UIViewController {
         dismiss(animated: true)
     }
     
-    @IBAction func reloadButton(_ sender: Any?) {
-        weatherModel.fetchWeather(){ result in
-            self.handleWeatherChange(result: result)
-        }
+    @IBAction func reloadButton(_ sender: Any) {
+        let result = weatherModel.fetchWeather()
+        
+        self.handleWeatherChange(result: result)
     }
     
     override func viewDidLoad() {
@@ -38,9 +34,9 @@ final class MainViewController: UIViewController {
     }
     
     @objc func viewWillEnterForeground(_ notification: Notification) {
-        weatherModel.fetchWeather(){ result in
-            self.handleWeatherChange(result: result)
-        }
+        let result = weatherModel.fetchWeather()
+        
+        self.handleWeatherChange(result: result)
     }
     
     func handleWeatherChange(result: Result<Response, Error>) {

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-final class MainViewController: UIViewController {
+class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
-    private var weatherModel = WeatherModel()
+    var weatherModel = WeatherModel()
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -6,18 +6,27 @@
 //
 
 import UIKit
+import YumemiWeather
 
-class MainViewController: UIViewController {
+protocol  WeatherModel {
+    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void)
+    func request<T: Encodable>(from value: T) throws -> String
+    func decode<T: Decodable>(from value: String) throws -> T
+}
+
+final class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
-    var weatherModel = WeatherModel()
+    var weatherModel: WeatherModel!
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)
     }
     
-    @IBAction func reloadButton(_ sender: Any) {
-        weatherModel.fetchWeather()
+    @IBAction func reloadButton(_ sender: Any?) {
+        weatherModel.fetchWeather(){ result in
+            self.handleWeatherChange(result: result)
+        }
     }
     
     override func viewDidLoad() {
@@ -29,46 +38,59 @@ class MainViewController: UIViewController {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
-        weatherModel.notificationCenter.addObserver(
-            self,
-            selector: #selector(self.handleWeatherChange(_:)),
-            name: .weatherModelChanged,
-            object: nil
-        )
-        weatherModel.notificationCenter.addObserver(
-            self,
-            selector: #selector(self.handleErrorOccurred(_:)),
-            name: .errorOccurred,
-            object: nil
-        )
     }
     
     @objc func viewWillEnterForeground(_ notification: Notification) {
-        weatherModel.fetchWeather()
-    }
-    
-    @objc func handleWeatherChange(_ notification: Notification) {
-        if let weather = notification.object as? Response {
-            weatherView.set(response: weather)
+        weatherModel.fetchWeather(){ result in
+            self.handleWeatherChange(result: result)
         }
     }
     
-    @objc func handleErrorOccurred(_ notification: Notification) {
-        if let error = notification.object as? String {
-            let alertController: UIAlertController = UIAlertController(
-                title:"Error",
-                message: error,
-                preferredStyle: .alert
-            )
-            
-            let defaultAction: UIAlertAction = UIAlertAction(
-                title: "Close",
-                style: .default,
-                handler: nil
-            )
-            
-            alertController.addAction(defaultAction)
-            present(alertController, animated: true, completion: nil)
+    func handleWeatherChange(result: Result<Response, Error>) {
+        switch result {
+        case .success(let responce):
+            weatherView.set(response: responce)
+        case .failure(let error):
+            handleErrorOccurred(error: error)
         }
+    }
+    
+    func handleErrorOccurred(error: Error) {
+        var message: String
+        
+        switch error {
+        case let error as YumemiWeatherError:
+            switch error {
+            case .invalidParameterError:
+                message = "Yumemi Weather Error\n'Invalid Parameter'"
+            case .unknownError:
+                message = "Yumemi Weather Error\n'Unknown'"
+            }
+        case let error as JsonError:
+            switch error {
+            case .decodeError:
+                message = "Json Error\n'Decode'"
+            case .encodeError:
+                message = "Json Error\n'Encode'"
+            case .convertError:
+                message = "Json Error\n'Convert'"
+            }
+        default:
+            message = "Unknown Error Occurred"
+        }
+        
+        let alertController: UIAlertController = UIAlertController(
+            title:"Error",
+            message: message,
+            preferredStyle: .alert
+        )
+        let defaultAction: UIAlertAction = UIAlertAction(
+            title: "Close",
+            style: .default,
+            handler: nil
+        )
+        
+        alertController.addAction(defaultAction)
+        present(alertController, animated: true, completion: nil)
     }
 }

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
-    var weatherModel: WeatherModel!
+    private (set) var weatherModel = WeatherModelImpl()
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class MainViewController: UIViewController {
     
     @IBOutlet var weatherView: WeatherView!
-    private (set) var weatherModel = WeatherModelImpl()
+    private (set) var weatherModel: WeatherModel = WeatherModelImpl()
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import YumemiWeather
 
 protocol  WeatherModel {
     func fetchWeather(completion: (Result<Response, Error>) -> Void)

--- a/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
@@ -6,15 +6,13 @@
 //
 
 import UIKit
+import Rswift
 
 final class NewViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        let viewController = R.storyboard.main.mainViewController()!
-        viewController.weatherModel = WeatherModelImpl()
-        viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: true, completion: nil)
+        performSegue(withIdentifier: R.segue.newViewController.toMainViewController, sender: nil)
     }
 }

--- a/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Rswift
 
 final class NewViewController: UIViewController {
 

--- a/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/NewViewController.swift
@@ -11,6 +11,10 @@ final class NewViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        performSegue(withIdentifier: R.segue.newViewController.toMainViewController.identifier, sender: nil)
+        
+        let viewController = R.storyboard.main.mainViewController()!
+        viewController.weatherModel = WeatherModelImpl()
+        viewController.modalPresentationStyle = .fullScreen
+        present(viewController, animated: true, completion: nil)
     }
 }

--- a/Yumemi-Weather/Yumemi-Weather/JsonParser.swift
+++ b/Yumemi-Weather/Yumemi-Weather/JsonParser.swift
@@ -1,0 +1,35 @@
+//
+//  JsonParser.swift
+//  Yumemi-Weather
+//
+//  Created by 清浦 駿 on 2021/07/01.
+//
+
+import Foundation
+
+class JsonParser {
+    
+    func request<T>(from value: T) throws -> String where T : Encodable {
+        let encoder = JSONEncoder()
+        guard let encodedDate = try? encoder.encode(value),
+              let jsonString = String(data: encodedDate, encoding: .utf8) else {
+            throw JsonError.encodeError
+        }
+        
+        return jsonString
+    }
+    
+    func decode<T>(from value: String) throws -> T where T : Decodable {
+        guard let jsonData: Data = value.data(using: .utf8) else {
+            throw JsonError.convertError
+        }
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        guard let response = try? jsonDecoder.decode(T.self, from: jsonData) else {
+            throw JsonError.decodeError
+        }
+        
+        return response
+    }
+}

--- a/Yumemi-Weather/Yumemi-Weather/JsonParser.swift
+++ b/Yumemi-Weather/Yumemi-Weather/JsonParser.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class JsonParser {
     
-    func request<T>(from value: T) throws -> String where T : Encodable {
+    func encode<T>(from value: T) throws -> String where T : Encodable {
         let encoder = JSONEncoder()
         guard let encodedDate = try? encoder.encode(value),
               let jsonString = String(data: encodedDate, encoding: .utf8) else {

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -48,7 +48,7 @@ final class WeatherModelImpl: WeatherModel {
 
 }
 
-public enum WeatherError: Error {
+enum WeatherError: Error {
     case invalidParameterError
     case unknownError
 }

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -12,12 +12,9 @@ protocol  WeatherModel: AnyObject {
     func fetchWeather() -> (Result<Response, Error>)
 }
 
-protocol JsonParser: AnyObject {
-    func request<T: Encodable>(from value: T) throws -> String
-    func decode<T: Decodable>(from value: String) throws -> T
-}
-
-final class WeatherModelImpl: WeatherModel, JsonParser {
+final class WeatherModelImpl: WeatherModel {
+    let jsonParser = JsonParser()
+    
     private let date: String = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
@@ -29,9 +26,9 @@ final class WeatherModelImpl: WeatherModel, JsonParser {
     
     func fetchWeather() -> (Result<Response, Error>) {
         do {
-            let request = try request(from: Request(area: "tokyo", date: date))
+            let request = try jsonParser.request(from: Request(area: "tokyo", date: date))
             let weather = try YumemiWeather.fetchWeather(request)
-            let weatherData: Response = try decode(from: weather)
+            let weatherData: Response = try jsonParser.decode(from: weather)
             
             return .success(weatherData)
         } catch {
@@ -48,29 +45,7 @@ final class WeatherModelImpl: WeatherModel, JsonParser {
         }
     }
     
-    func request<T>(from value: T) throws -> String where T : Encodable {
-        let encoder = JSONEncoder()
-        guard let encodedDate = try? encoder.encode(value),
-              let jsonString = String(data: encodedDate, encoding: .utf8) else {
-            throw JsonError.encodeError
-        }
-        
-        return jsonString
-    }
-    
-    func decode<T>(from value: String) throws -> T where T : Decodable {
-        guard let jsonData: Data = value.data(using: .utf8) else {
-            throw JsonError.convertError
-        }
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        
-        guard let response = try? jsonDecoder.decode(T.self, from: jsonData) else {
-            throw JsonError.decodeError
-        }
-        
-        return response
-    }
+
 }
 
 public enum WeatherError: Error {

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -75,7 +75,7 @@ class WeatherModel {
         }
     }
     
-    private func request<T: Encodable>(from value: T) throws -> String {
+    func request<T: Encodable>(from value: T) throws -> String {
         let encoder = JSONEncoder()
         guard let encodedDate = try? encoder.encode(value),
               let jsonString = String(data: encodedDate, encoding: .utf8) else {
@@ -85,7 +85,7 @@ class WeatherModel {
         return jsonString
     }
     
-    private func decode<T: Decodable>(from value: String) throws -> T {
+    func decode<T: Decodable>(from value: String) throws -> T {
         guard let jsonData: Data = value.data(using: .utf8) else {
             throw JsonError.convertError
         }

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -26,7 +26,7 @@ final class WeatherModelImpl: WeatherModel {
     
     func fetchWeather() -> (Result<Response, Error>) {
         do {
-            let request = try jsonParser.request(from: Request(area: "tokyo", date: date))
+            let request = try jsonParser.encode(from: Request(area: "tokyo", date: date))
             let weather = try YumemiWeather.fetchWeather(request)
             let weatherData: Response = try jsonParser.decode(from: weather)
             

--- a/Yumemi-Weather/Yumemi-Weather/View/WeatherView.swift
+++ b/Yumemi-Weather/Yumemi-Weather/View/WeatherView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 import Rswift
 
-class WeatherView: UIView {
+final class WeatherView: UIView {
     
     @IBOutlet weak var weatherImageView: UIImageView!
     @IBOutlet weak var minTempLabel: UILabel!

--- a/Yumemi-Weather/Yumemi-WeatherTests/JsonParseTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/JsonParseTests.swift
@@ -1,0 +1,58 @@
+//
+//  JsonParseTests.swift
+//  Yumemi-WeatherTests
+//
+//  Created by 清浦 駿 on 2021/06/30.
+//
+
+import XCTest
+@testable import Yumemi_Weather
+
+class JsonParseTests: XCTestCase {
+    
+    var jsonPerser: JsonParserMock!
+    
+    override func setUp() {
+        jsonPerser = JsonParserMock()
+    }
+    
+    func test_Jsonのエンコード() throws {
+        let expectedResult = """
+{"date":"","area":""}
+"""
+        let result = try jsonPerser.request(from: Request(area: "", date: ""))
+        
+        XCTAssertEqual(result, expectedResult)
+    }
+    
+    func test_Jsonのデコード() throws {
+        let expectedResult = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
+        let jsonString = """
+{"max_temp":0,"min_temp":0,"date":"","weather":""}
+"""
+        let result: Response = try jsonPerser.decode(from: jsonString)
+        
+        XCTAssertEqual(result.maxTemp, expectedResult.maxTemp)
+        XCTAssertEqual(result.minTemp, expectedResult.minTemp)
+        XCTAssertEqual(result.date, expectedResult.date)
+        XCTAssertEqual(result.weather, expectedResult.weather)
+    }
+}
+
+class JsonParserMock: JsonParser {
+    func request<T>(from value: T) throws -> String where T : Encodable {
+        let encoder = JSONEncoder()
+        let encodedDate = try encoder.encode(value)
+        
+        return String(data: encodedDate, encoding: .utf8)!
+    }
+    
+    func decode<T>(from value: String) throws -> T where T : Decodable {
+        let jsonData: Data = value.data(using: .utf8)!
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        let decodedData = try jsonDecoder.decode(T.self, from: jsonData)
+        
+        return decodedData
+    }
+}

--- a/Yumemi-Weather/Yumemi-WeatherTests/JsonParseTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/JsonParseTests.swift
@@ -10,11 +10,7 @@ import XCTest
 
 class JsonParseTests: XCTestCase {
     
-    var jsonPerser: JsonParserMock!
-    
-    override func setUp() {
-        jsonPerser = JsonParserMock()
-    }
+    var jsonPerser: JsonParser = WeatherModelImpl()
     
     func test_Jsonのエンコード() throws {
         let expectedResult = """

--- a/Yumemi-Weather/Yumemi-WeatherTests/JsonParserTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/JsonParserTests.swift
@@ -8,9 +8,9 @@
 import XCTest
 @testable import Yumemi_Weather
 
-class JsonParseTests: XCTestCase {
+class JsonParserTests: XCTestCase {
     
-    var jsonPerser: JsonParser = WeatherModelImpl()
+    let jsonPerser = JsonParser()
     
     func test_Jsonのエンコード() throws {
         let expectedResult = """
@@ -32,23 +32,5 @@ class JsonParseTests: XCTestCase {
         XCTAssertEqual(result.minTemp, expectedResult.minTemp)
         XCTAssertEqual(result.date, expectedResult.date)
         XCTAssertEqual(result.weather, expectedResult.weather)
-    }
-}
-
-class JsonParserMock: JsonParser {
-    func request<T>(from value: T) throws -> String where T : Encodable {
-        let encoder = JSONEncoder()
-        let encodedDate = try encoder.encode(value)
-        
-        return String(data: encodedDate, encoding: .utf8)!
-    }
-    
-    func decode<T>(from value: String) throws -> T where T : Decodable {
-        let jsonData: Data = value.data(using: .utf8)!
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        let decodedData = try jsonDecoder.decode(T.self, from: jsonData)
-        
-        return decodedData
     }
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/JsonParserTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/JsonParserTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import Yumemi_Weather
 
-class JsonParserTests: XCTestCase {
+final class JsonParserTests: XCTestCase {
     
     let jsonPerser = JsonParser()
     
@@ -16,7 +16,7 @@ class JsonParserTests: XCTestCase {
         let expectedResult = """
 {"date":"","area":""}
 """
-        let result = try jsonPerser.request(from: Request(area: "", date: ""))
+        let result = try jsonPerser.encode(from: Request(area: "", date: ""))
         
         XCTAssertEqual(result, expectedResult)
     }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -11,46 +11,46 @@ import XCTest
 class Yumemi_WeatherTests: XCTestCase {
     
     var mainViewController: MainViewController!
-    var weatherModel: WeatherModel!
+    var weatherModel: WeatherModelMock!
     var weatherView: WeatherView!
 
     override func setUpWithError() throws {
-        weatherModel = WeatherModel()
+        weatherModel = WeatherModelMock()
         mainViewController = R.storyboard.main.mainViewController()!
         mainViewController.weatherModel = weatherModel
         _ = mainViewController.view
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
     
-    func testSetSunnyImageToWeatherImageViewWhenWeatherIsSunny() throws {
-        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny"))
+    func test_天気が晴れの時WeatherImageViewに晴れの画像が表示される() throws {
+        weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny")
+        mainViewController.reloadButton(UIButton())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.sunny())
     }
     
-    func testSetCloudyImageToWeatherImageViewWhenWeatherIsCloudy() throws {
-        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy"))
+    func test_天気が曇りの時WeatherImageViewに曇りの画像が表示される() throws {
+        weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy")
+        mainViewController.reloadButton(UIButton())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
     }
     
-    func testSetRainyImageToWeatherImageViewWhenWeatherIsRainy() throws {
-        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy"))
+    func test天気が雨の時にWeatherImageViewに雨の画像が表示される() throws {
+        weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
+        mainViewController.reloadButton(UIButton())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.rainy())
     }
     
-    func testSetTempretureToUILabel() throws {
-        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny"))
+    func test_気温がUILabelに表示されるかのテスト() throws {
+        weatherModel.response = Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
+        mainViewController.reloadButton(UIButton())
         XCTAssertEqual(mainViewController.weatherView.maxTempLabel.text, "10")
         XCTAssertEqual(mainViewController.weatherView.minTempLabel.text, "0")
     }
     
-    func testJsonEncode() throws {
+    func test_Jsonのエンコード() throws {
         let jsonString = """
 {"date":"","area":""}
 """
@@ -60,7 +60,7 @@ class Yumemi_WeatherTests: XCTestCase {
         XCTAssertEqual(result, jsonString)
     }
     
-    func testJsonDecode() throws {
+    func test_Jsonのデコード() throws {
         let jsonString = """
 {"max_temp":0,"min_temp":0,"date":"","weather":""}
 """
@@ -73,4 +73,37 @@ class Yumemi_WeatherTests: XCTestCase {
         XCTAssertEqual(response.weather, result.weather)
     }
 
+}
+
+class WeatherModelMock: WeatherModel {
+    var response: Response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
+    
+    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void) {
+        completion(.success(response))
+    }
+    
+    func request<T>(from value: T) throws -> String where T : Encodable {
+        let encoder = JSONEncoder()
+        guard let encodedDate = try? encoder.encode(value),
+              let jsonString = String(data: encodedDate, encoding: .utf8) else {
+            throw JsonError.encodeError
+        }
+        
+        return jsonString
+    }
+    
+    func decode<T>(from value: String) throws -> T where T : Decodable {
+        guard let jsonData: Data = value.data(using: .utf8) else {
+            throw JsonError.convertError
+        }
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        guard let response = try? jsonDecoder.decode(T.self, from: jsonData) else {
+            throw JsonError.decodeError
+        }
+        
+        return response
+    }
+    
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -9,25 +9,68 @@ import XCTest
 @testable import Yumemi_Weather
 
 class Yumemi_WeatherTests: XCTestCase {
+    
+    var mainViewController: MainViewController!
+    var weatherModel: WeatherModel!
+    var weatherView: WeatherView!
 
     override func setUpWithError() throws {
+        weatherModel = WeatherModel()
+        mainViewController = R.storyboard.main.mainViewController()!
+        mainViewController.weatherModel = weatherModel
+        _ = mainViewController.view
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    
+    func testSetSunnyImageToWeatherImageViewWhenWeatherIsSunny() throws {
+        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny"))
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.sunny())
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    
+    func testSetCloudyImageToWeatherImageViewWhenWeatherIsCloudy() throws {
+        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy"))
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
+    }
+    
+    func testSetRainyImageToWeatherImageViewWhenWeatherIsRainy() throws {
+        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy"))
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
+        XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.rainy())
+    }
+    
+    func testSetTempretureToUILabel() throws {
+        weatherModel.notificationCenter.post(name: .weatherModelChanged, object: Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny"))
+        XCTAssertEqual(mainViewController.weatherView.maxTempLabel.text, "10")
+        XCTAssertEqual(mainViewController.weatherView.minTempLabel.text, "0")
+    }
+    
+    func testJsonEncode() throws {
+        let jsonString = """
+{"date":"","area":""}
+"""
+        let request = Request(area: "", date: "")
+        let result = try weatherModel.request(from: request)
+        
+        XCTAssertEqual(result, jsonString)
+    }
+    
+    func testJsonDecode() throws {
+        let jsonString = """
+{"max_temp":0,"min_temp":0,"date":"","weather":""}
+"""
+        let response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
+        let result: Response = try weatherModel.decode(from: jsonString)
+        
+        XCTAssertEqual(response.maxTemp, result.maxTemp)
+        XCTAssertEqual(response.minTemp, result.minTemp)
+        XCTAssertEqual(response.date, result.date)
+        XCTAssertEqual(response.weather, result.weather)
     }
 
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -22,55 +22,68 @@ class Yumemi_WeatherTests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
     
-    func test_天気が晴れの時WeatherImageViewに晴れの画像が表示される() throws {
+    func test_天気が晴れの時WeatherImageViewに晴れの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny")
-        mainViewController.reloadButton(UIButton())
+        weatherModel.fetchWeather(){ result in
+            mainViewController.handleWeatherChange(result: result)
+        }
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.sunny())
     }
     
-    func test_天気が曇りの時WeatherImageViewに曇りの画像が表示される() throws {
+    func test_天気が曇りの時WeatherImageViewに曇りの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy")
-        mainViewController.reloadButton(UIButton())
+        weatherModel.fetchWeather(){ result in
+            mainViewController.handleWeatherChange(result: result)
+        }
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
     }
     
-    func test天気が雨の時にWeatherImageViewに雨の画像が表示される() throws {
+    func test天気が雨の時にWeatherImageViewに雨の画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        mainViewController.reloadButton(UIButton())
+        weatherModel.fetchWeather(){ result in
+            mainViewController.handleWeatherChange(result: result)
+        }
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.rainy())
     }
     
-    func test_気温がUILabelに表示されるかのテスト() throws {
+    func test_気温がUILabelに設定される() throws {
         weatherModel.response = Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        mainViewController.reloadButton(UIButton())
+        weatherModel.fetchWeather(){ result in
+            mainViewController.handleWeatherChange(result: result)
+        }
         XCTAssertEqual(mainViewController.weatherView.maxTempLabel.text, "10")
         XCTAssertEqual(mainViewController.weatherView.minTempLabel.text, "0")
     }
     
     func test_Jsonのエンコード() throws {
-        let jsonString = """
+        let expectedResult = """
 {"date":"","area":""}
 """
         let request = Request(area: "", date: "")
-        let result = try weatherModel.request(from: request)
+        let encoder = JSONEncoder()
+        let encodedDate = try encoder.encode(request)
+        let result = String(data: encodedDate, encoding: .utf8)
         
-        XCTAssertEqual(result, jsonString)
+        XCTAssertEqual(result, expectedResult)
     }
     
     func test_Jsonのデコード() throws {
+        let expectedResult = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
         let jsonString = """
 {"max_temp":0,"min_temp":0,"date":"","weather":""}
 """
-        let response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
-        let result: Response = try weatherModel.decode(from: jsonString)
+        let jsonData: Data = jsonString.data(using: .utf8)!
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        let result = try jsonDecoder.decode(Response.self, from: jsonData)
         
-        XCTAssertEqual(response.maxTemp, result.maxTemp)
-        XCTAssertEqual(response.minTemp, result.minTemp)
-        XCTAssertEqual(response.date, result.date)
-        XCTAssertEqual(response.weather, result.weather)
+        XCTAssertEqual(result.maxTemp, expectedResult.maxTemp)
+        XCTAssertEqual(result.minTemp, expectedResult.minTemp)
+        XCTAssertEqual(result.date, expectedResult.date)
+        XCTAssertEqual(result.weather, expectedResult.weather)
     }
 
 }
@@ -78,32 +91,7 @@ class Yumemi_WeatherTests: XCTestCase {
 class WeatherModelMock: WeatherModel {
     var response: Response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
     
-    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void) {
+    func fetchWeather(completion: (Result<Response, Error>) -> Void) {
         completion(.success(response))
     }
-    
-    func request<T>(from value: T) throws -> String where T : Encodable {
-        let encoder = JSONEncoder()
-        guard let encodedDate = try? encoder.encode(value),
-              let jsonString = String(data: encodedDate, encoding: .utf8) else {
-            throw JsonError.encodeError
-        }
-        
-        return jsonString
-    }
-    
-    func decode<T>(from value: String) throws -> T where T : Decodable {
-        guard let jsonData: Data = value.data(using: .utf8) else {
-            throw JsonError.convertError
-        }
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        
-        guard let response = try? jsonDecoder.decode(T.self, from: jsonData) else {
-            throw JsonError.decodeError
-        }
-        
-        return response
-    }
-    
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -24,74 +24,41 @@ class Yumemi_WeatherTests: XCTestCase {
     
     func test_天気が晴れの時WeatherImageViewに晴れの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny")
-        weatherModel.fetchWeather(){ result in
-            mainViewController.handleWeatherChange(result: result)
-        }
+        let result = mainViewController.weatherModel.fetchWeather()
+        mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.sunny())
     }
     
     func test_天気が曇りの時WeatherImageViewに曇りの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy")
-        weatherModel.fetchWeather(){ result in
-            mainViewController.handleWeatherChange(result: result)
-        }
+        let result = mainViewController.weatherModel.fetchWeather()
+        mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
     }
     
     func test天気が雨の時にWeatherImageViewに雨の画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        weatherModel.fetchWeather(){ result in
-            mainViewController.handleWeatherChange(result: result)
-        }
+        let result = mainViewController.weatherModel.fetchWeather()
+        mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.rainy())
     }
     
     func test_気温がUILabelに設定される() throws {
         weatherModel.response = Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        weatherModel.fetchWeather(){ result in
-            mainViewController.handleWeatherChange(result: result)
-        }
+        let result = mainViewController.weatherModel.fetchWeather()
+        mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.maxTempLabel.text, "10")
         XCTAssertEqual(mainViewController.weatherView.minTempLabel.text, "0")
     }
-    
-    func test_Jsonのエンコード() throws {
-        let expectedResult = """
-{"date":"","area":""}
-"""
-        let request = Request(area: "", date: "")
-        let encoder = JSONEncoder()
-        let encodedDate = try encoder.encode(request)
-        let result = String(data: encodedDate, encoding: .utf8)
-        
-        XCTAssertEqual(result, expectedResult)
-    }
-    
-    func test_Jsonのデコード() throws {
-        let expectedResult = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
-        let jsonString = """
-{"max_temp":0,"min_temp":0,"date":"","weather":""}
-"""
-        let jsonData: Data = jsonString.data(using: .utf8)!
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        let result = try jsonDecoder.decode(Response.self, from: jsonData)
-        
-        XCTAssertEqual(result.maxTemp, expectedResult.maxTemp)
-        XCTAssertEqual(result.minTemp, expectedResult.minTemp)
-        XCTAssertEqual(result.date, expectedResult.date)
-        XCTAssertEqual(result.weather, expectedResult.weather)
-    }
-
 }
 
 class WeatherModelMock: WeatherModel {
     var response: Response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
     
-    func fetchWeather(completion: (Result<Response, Error>) -> Void) {
-        completion(.success(response))
+    func fetchWeather() -> (Result<Response, Error>) {
+        return .success(response)
     }
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -17,14 +17,13 @@ class Yumemi_WeatherTests: XCTestCase {
     override func setUpWithError() throws {
         weatherModel = WeatherModelMock()
         mainViewController = R.storyboard.main.mainViewController()!
-        mainViewController.weatherModel = weatherModel
         _ = mainViewController.view
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
     
     func test_天気が晴れの時WeatherImageViewに晴れの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny")
-        let result = mainViewController.weatherModel.fetchWeather()
+        let result = weatherModel.fetchWeather()
         mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.sunny())
@@ -32,7 +31,7 @@ class Yumemi_WeatherTests: XCTestCase {
     
     func test_天気が曇りの時WeatherImageViewに曇りの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy")
-        let result = mainViewController.weatherModel.fetchWeather()
+        let result = weatherModel.fetchWeather()
         mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
@@ -40,7 +39,7 @@ class Yumemi_WeatherTests: XCTestCase {
     
     func test天気が雨の時にWeatherImageViewに雨の画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        let result = mainViewController.weatherModel.fetchWeather()
+        let result = weatherModel.fetchWeather()
         mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
         XCTAssertEqual(mainViewController.weatherView.weatherImageView.image, R.image.rainy())
@@ -48,7 +47,7 @@ class Yumemi_WeatherTests: XCTestCase {
     
     func test_気温がUILabelに設定される() throws {
         weatherModel.response = Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        let result = mainViewController.weatherModel.fetchWeather()
+        let result = weatherModel.fetchWeather()
         mainViewController.handleWeatherChange(result: result)
         XCTAssertEqual(mainViewController.weatherView.maxTempLabel.text, "10")
         XCTAssertEqual(mainViewController.weatherView.minTempLabel.text, "0")


### PR DESCRIPTION
## [session/8](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/UnitTest.md)

# 変更理由
- 単体テストを実装するため

# 変更点
- テストで使うために関数や変数のスコープを広くした
- 天気がImageViewに表示されるかのテストを実装
- 気温がLabelに表示されるかのテストを実装
- JsonのEncode、Decodeのテストを実装

# 参考資料
- [【初心者向け】テストコードの方針を考える（何をテストすべきか？どんなテストを書くべきか？）](https://qiita.com/jnchito/items/2a5d3e15761fd413657a)
- [SwiftでのXCTestについて](https://qiita.com/sunstripe2011/items/8102e79b4b3c71ab3508)
- [XCTest | Apple Developer Documentation](https://developer.apple.com/documentation/xctest)