### PR TITLE
session10 -delegate

### DIFF
--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-final class MainViewController: UIViewController {
+final class MainViewController: UIViewController, WeatherModelDelegate{
     
     @IBOutlet var weatherView: WeatherView!
-    private (set) var weatherModel: WeatherModel = WeatherModelImpl()
+    private (set) var weatherModel = WeatherModelImpl()
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)
@@ -18,17 +18,13 @@ final class MainViewController: UIViewController {
     
     @IBAction func reloadButton(_ sender: Any) {
         weatherView.activityIndicatorViewStartAnimating()
-        weatherModel.fetchWeather { result in
-            DispatchQueue.main.async {
-                self.weatherView.activityIndicatorViewStopAnimating()
-                self.handleWeatherChange(result: result)
-            }
-        }
+        weatherModel.fetchWeather()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        weatherModel.delegate = self
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(self.viewWillEnterForeground(_:)),
@@ -37,13 +33,19 @@ final class MainViewController: UIViewController {
         )
     }
     
+    deinit {
+        print("deinit called")
+    }
+    
     @objc func viewWillEnterForeground(_ notification: Notification) {
         weatherView.activityIndicatorViewStartAnimating()
-        weatherModel.fetchWeather { result in
-            DispatchQueue.main.async {
-                self.weatherView.activityIndicatorViewStopAnimating()
-                self.handleWeatherChange(result: result)
-            }
+        weatherModel.fetchWeather()
+    }
+    
+    func fetchWeatherDidFinished(result: Result<Response, Error>) {
+        DispatchQueue.main.async {
+            self.weatherView.activityIndicatorViewStopAnimating()
+            self.handleWeatherChange(result: result)
         }
     }
     

--- a/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Controller/MainViewController.swift
@@ -7,10 +7,10 @@
 
 import UIKit
 
-final class MainViewController: UIViewController, WeatherModelDelegate{
+final class MainViewController: UIViewController{
     
     @IBOutlet var weatherView: WeatherView!
-    private (set) var weatherModel = WeatherModelImpl()
+    private (set) var weatherModel: WeatherModel = WeatherModelImpl()
     
     @IBAction func closeButton(_ sender: Any) {
         dismiss(animated: true)
@@ -40,22 +40,6 @@ final class MainViewController: UIViewController, WeatherModelDelegate{
     @objc func viewWillEnterForeground(_ notification: Notification) {
         weatherView.activityIndicatorViewStartAnimating()
         weatherModel.fetchWeather()
-    }
-    
-    func fetchWeatherDidFinished(result: Result<Response, Error>) {
-        DispatchQueue.main.async {
-            self.weatherView.activityIndicatorViewStopAnimating()
-            self.handleWeatherChange(result: result)
-        }
-    }
-    
-    func handleWeatherChange(result: Result<Response, Error>) {
-        switch result {
-        case .success(let response):
-            weatherView.set(response: response)
-        case .failure(let error):
-            handleErrorOccurred(error: error)
-        }
     }
     
     func handleErrorOccurred(error: Error) {
@@ -100,5 +84,21 @@ final class MainViewController: UIViewController, WeatherModelDelegate{
         }
         
         return message
+    }
+}
+
+extension MainViewController: WeatherModelDelegate {
+    func fetchWeatherDidSucceed(response: Response) {
+        DispatchQueue.main.async {
+            self.weatherView.activityIndicatorViewStopAnimating()
+            self.weatherView.set(response: response)
+        }
+    }
+    
+    func fetchWeatherDidFail(error: Error) {
+        DispatchQueue.main.async {
+            self.weatherView.activityIndicatorViewStopAnimating()
+            self.handleErrorOccurred(error: error)
+        }
     }
 }

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -9,11 +9,13 @@ import Foundation
 import YumemiWeather
 
 protocol WeatherModel: AnyObject {
+    var delegate: WeatherModelDelegate? { get set }
     func fetchWeather()
 }
 
 protocol WeatherModelDelegate: AnyObject {
-    func fetchWeatherDidFinished(result: Result<Response, Error>)
+    func fetchWeatherDidSucceed(response: Response)
+    func fetchWeatherDidFail(error: Error)
 }
 
 final class WeatherModelImpl: WeatherModel {
@@ -36,11 +38,11 @@ final class WeatherModelImpl: WeatherModel {
                 let weather: String = try YumemiWeather.syncFetchWeather(request)
                 let weatherData: Response = try self.jsonParser.decode(from: weather)
                 
-                self.delegate?.fetchWeatherDidFinished(result: .success(weatherData))
+                self.delegate?.fetchWeatherDidSucceed(response: weatherData)
             } catch let error as YumemiWeatherError {
-                self.delegate?.fetchWeatherDidFinished(result: .failure(WeatherError(error: error)))
+                self.delegate?.fetchWeatherDidFail(error: WeatherError(error: error))
             } catch {
-                self.delegate?.fetchWeatherDidFinished(result: .failure(error))
+                self.delegate?.fetchWeatherDidFail(error: error)
             }
         }
     }

--- a/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
+++ b/Yumemi-Weather/Yumemi-Weather/Model/WeatherModel.swift
@@ -9,10 +9,15 @@ import Foundation
 import YumemiWeather
 
 protocol WeatherModel: AnyObject {
-    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void)
+    func fetchWeather()
+}
+
+protocol WeatherModelDelegate: AnyObject {
+    func fetchWeatherDidFinished(result: Result<Response, Error>)
 }
 
 final class WeatherModelImpl: WeatherModel {
+    weak var delegate: WeatherModelDelegate?
     let jsonParser = JsonParser()
     
     private let date: String = {
@@ -24,18 +29,18 @@ final class WeatherModelImpl: WeatherModel {
         return dateString
     }()
     
-    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void) {
+    func fetchWeather() {
         DispatchQueue.global().async {
             do {
                 let request: String = try self.jsonParser.encode(from: Request(area: "tokyo", date: self.date))
                 let weather: String = try YumemiWeather.syncFetchWeather(request)
                 let weatherData: Response = try self.jsonParser.decode(from: weather)
                 
-                completion(.success(weatherData))
+                self.delegate?.fetchWeatherDidFinished(result: .success(weatherData))
             } catch let error as YumemiWeatherError {
-                completion(.failure(WeatherError(error: error)))
+                self.delegate?.fetchWeatherDidFinished(result: .failure(WeatherError(error: error)))
             } catch {
-                completion(.failure(error))
+                self.delegate?.fetchWeatherDidFinished(result: .failure(error))
             }
         }
     }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -13,9 +13,10 @@ final class Yumemi_WeatherTests: XCTestCase {
     var mainViewController: MainViewController!
     var weatherModel: WeatherModelMock!
     var weatherView: WeatherView!
-
+    
     override func setUpWithError() throws {
         weatherModel = WeatherModelMock()
+        weatherModel.delegate = self
         mainViewController = R.storyboard.main.mainViewController()!
         _ = mainViewController.view
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -23,45 +24,44 @@ final class Yumemi_WeatherTests: XCTestCase {
     
     func test_天気が晴れの時WeatherImageViewに晴れの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "sunny")
-        weatherModel.fetchWeather { result in
-            self.mainViewController.handleWeatherChange(result: result)
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.sunny())
-        }
+        weatherModel.fetchWeather()
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.sun())
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.sunny())
     }
     
     func test_天気が曇りの時WeatherImageViewに曇りの画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "cloudy")
-        weatherModel.fetchWeather { result in
-            self.mainViewController.handleWeatherChange(result: result)
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
-        }
+        weatherModel.fetchWeather()
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.cloud())
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.cloudy())
     }
     
     func test天気が雨の時にWeatherImageViewに雨の画像が設定される() throws {
         weatherModel.response = Response(maxTemp: 0, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        weatherModel.fetchWeather { result in
-            self.mainViewController.handleWeatherChange(result: result)
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
-            XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.rainy())
-        }
+        weatherModel.fetchWeather()
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.tintColor, R.color.umbrella())
+        XCTAssertEqual(self.mainViewController.weatherView.weatherImageView.image, R.image.rainy())
     }
     
     func test_気温がUILabelに設定される() throws {
         weatherModel.response = Response(maxTemp: 10, minTemp: 0, date: "2020-04-01T12:00:00+09:00", weather: "rainy")
-        weatherModel.fetchWeather { result in
-            self.mainViewController.handleWeatherChange(result: result)
-            XCTAssertEqual(self.mainViewController.weatherView.maxTempLabel.text, "10")
-            XCTAssertEqual(self.mainViewController.weatherView.minTempLabel.text, "0")
-        }
+        weatherModel.fetchWeather()
+        XCTAssertEqual(self.mainViewController.weatherView.maxTempLabel.text, "10")
+        XCTAssertEqual(self.mainViewController.weatherView.minTempLabel.text, "0")
+    }
+}
+
+extension Yumemi_WeatherTests: WeatherModelDelegate {
+    func fetchWeatherDidFinished(result: Result<Response, Error>) {
+        mainViewController.handleWeatherChange(result: result)
     }
 }
 
 class WeatherModelMock: WeatherModel {
     var response: Response = Response(maxTemp: 0, minTemp: 0, date: "", weather: "")
+    weak var delegate: WeatherModelDelegate?
     
-    func fetchWeather(completion: @escaping (Result<Response, Error>) -> Void) {
-        completion(.success(response))
+    func fetchWeather() {
+        delegate?.fetchWeatherDidFinished(result: .success(response))
     }
 }

--- a/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
+++ b/Yumemi-Weather/Yumemi-WeatherTests/Yumemi_WeatherTests.swift
@@ -52,8 +52,11 @@ final class Yumemi_WeatherTests: XCTestCase {
 }
 
 extension Yumemi_WeatherTests: WeatherModelDelegate {
-    func fetchWeatherDidFinished(result: Result<Response, Error>) {
-        mainViewController.handleWeatherChange(result: result)
+    func fetchWeatherDidSucceed(response: Response) {
+        mainViewController.weatherView.set(response: response)
+    }
+    
+    func fetchWeatherDidFail(error: Error) {
     }
 }
 
@@ -62,6 +65,6 @@ class WeatherModelMock: WeatherModel {
     weak var delegate: WeatherModelDelegate?
     
     func fetchWeather() {
-        delegate?.fetchWeatherDidFinished(result: .success(response))
+        delegate?.fetchWeatherDidSucceed(response: response)
     }
 }


### PR DESCRIPTION
# 変更理由
- delegateパターンの理解を深める

# 変更内容
- WeatherModelDelegateを実装
- 天気を扱う処理をfetchWeatherのcompletionでやっていたのをfetchWeatherDidFinishで行うように変更
- deinitを実装
- deinitでログを出力
- 変更に伴うテストコードの変更

# 参考文献
- [なぜDelegateをプロパティに持つとweakを指定しなければいけないの？](https://qiita.com/eKushida/items/d526b0c6d0e3221e77e0)
- [[iOS8] Swiftでdelegateを使ったモーダル間の値渡し](https://qiita.com/osamu1203/items/6dedc01e3b975a0ceec4)